### PR TITLE
Add the email type fields

### DIFF
--- a/src/util.php
+++ b/src/util.php
@@ -71,6 +71,7 @@ final class WPGraphQL_MetaBox_Util
             case 'textarea':
             case 'time':
             case 'select':
+            case 'email':
             case 'text':
             case 'url':
             case 'wysiwyg':
@@ -164,6 +165,7 @@ final class WPGraphQL_MetaBox_Util
             case 'textarea':
             case 'time':
             case 'select':
+            case 'email':
             case 'text':
             case 'fieldset_text':
             case 'text_list':


### PR DESCRIPTION
Hi,

I just added the email type fields. They are probably not in the Meta Box documentation because they behave exactly the same as the text fields with the difference that the input validation is added.