### PR TITLE
Add support for metabox text_list with clone option

### DIFF
--- a/src/util.php
+++ b/src/util.php
@@ -20,6 +20,7 @@ final class WPGraphQL_MetaBox_Util
         }
         $type = $field['type'];
         $multiple = $field['multiple'];
+        $clone = $field['clone'];
 
         switch ($type) {
             case 'autocomplete':
@@ -78,15 +79,12 @@ final class WPGraphQL_MetaBox_Util
             case 'wysiwyg':
                 return $multiple ?  ['list_of' => 'String'] : 'String';
             case 'fieldset_text':
-            case 'text_list':
             case 'select_advanced':
-                return [
-                    'list_of' => 'String',
-                ];
+                return ['list_of' => 'String'];
+            case 'text_list':
+                return $clone ? ['list_of' => ['list_of' => 'String']] : ['list_of' => 'String'];
             case 'key_value':
-                return [
-                    'list_of' => 'MBKeyValue',
-                ];
+                return ['list_of' => 'MBKeyValue'];
             case 'number':
             case 'range':
                 return $multiple ?  ['list_of' => 'Float'] : 'Float';


### PR DESCRIPTION
If you define a `text_list` with the option `'clone'   => true` the graphql model should be an array of string arrays.

```
function ingredients_register_meta_boxes( $meta_boxes ) {
	$meta_boxes[] = [
		'title'      => esc_html__( 'Ingredients' ),
		'id'         => 'zutaten',
		'post_types' => ['ingredients'],
		'context'    => 'normal',
		'priority'   => 'high',
		'fields'     => [
			[
				'type'    => 'text_list',
				'id'      => 'ingredients',
				'name'    => esc_html__( 'Ingredients' ),
				'desc'    => esc_html__( 'Specify the ingredients' ),
				'clone'   => true,
				'options' => [
					'100'    => 'Amount',
                                        'ml'     => 'Unit',
                                        'Water' => 'Name',
				],
				'graphql_name' => 'ingredients',
			],
		],
	];

	return $meta_boxes;
}

add_filter( 'rwmb_meta_boxes', 'ingredients_register_meta_boxes' );
```